### PR TITLE
Fix crash when variable google is undefined

### DIFF
--- a/lib/withGoogleMap.js
+++ b/lib/withGoogleMap.js
@@ -77,7 +77,6 @@ function withGoogleMap(BaseComponent) {
       var _ref
 
       var _temp, _this, _ret
-
       ;(0, _classCallCheck3.default)(this, Container)
 
       for (
@@ -128,7 +127,6 @@ function withGoogleMap(BaseComponent) {
           var _props = this.props,
             containerElement = _props.containerElement,
             mapElement = _props.mapElement
-
           ;(0, _invariant2.default)(
             !!containerElement && !!mapElement,
             "Required props containerElement or mapElement is missing. You need to provide both of them.\n The `google.maps.Map` instance will be initialized on mapElement and it's wrapped by containerElement.\nYou need to provide both of them since Google Map requires the DOM to have height when initialized."
@@ -138,7 +136,11 @@ function withGoogleMap(BaseComponent) {
       {
         key: "handleComponentMount",
         value: function handleComponentMount(node) {
-          if (this.state.map || node === null) {
+          if (
+            this.state.map ||
+            node === null ||
+            "undefined" === typeof google
+          ) {
             return
           }
           ;(0, _warning2.default)(

--- a/src/withGoogleMap.jsx
+++ b/src/withGoogleMap.jsx
@@ -46,7 +46,7 @@ export function withGoogleMap(BaseComponent) {
     }
 
     handleComponentMount(node) {
-      if (this.state.map || node === null) {
+      if (this.state.map || node === null || "undefined" === typeof google) {
         return
       }
       warning(


### PR DESCRIPTION
## PLEASE CHECK "Allow edits from maintainers"

![help](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits.png)

## FOLLOW "Conventional Commits Specification" FOR ALL COMMITS

https://conventionalcommits.org/

When the Google Maps Script couldn't be loaded properly MST site crashes:

![image](https://github.com/Dwell-io/react-google-maps/assets/40407898/72a10045-5ad1-4daa-8bfb-89d2e355c8dc)

